### PR TITLE
Recuva fix

### DIFF
--- a/Recuva/tools/regAdd.ps1
+++ b/Recuva/tools/regAdd.ps1
@@ -1,4 +1,4 @@
-﻿# This adds a registry key which prevents Google Chrome from getting installed together with Speccy
+﻿# This adds a registry key which prevents Google Chrome from getting installed together with Piriform software products
 
 $processor = Get-WmiObject Win32_Processor
 $is64bit = $processor.AddressWidth -eq 64


### PR DESCRIPTION
Unfortunately in some cases the Recuva package installs the Google Toolbar without asking, which is annoying. This PR fixes this problem.

Just merge and pull this and manually upload my [pre-built fixed Recuva package](https://github.com/TomOne/various/raw/master/Recuva.1.49.1019.20140102.nupkg) manually with cpush. Otherwise this issue will persist until Recuva gets a new version number, which could take months.

Please do this as soon as possible. People don’t like these crappy toolbars. :smile: 
