### PR TITLE
Skip starting of Visual Studio Code after installation

### DIFF
--- a/VisualStudioCode/Tools/ChocolateyInstall.ps1
+++ b/VisualStudioCode/Tools/ChocolateyInstall.ps1
@@ -1,6 +1,6 @@
 $packageName = '{{PackageName}}'
 $installerType = 'exe'
-$silentArgs = "/silent /log=""$env:temp\vscode.log"""
+$silentArgs = "/silent /mergetasks=!runcode /log=""$env:temp\vscode.log"""
 $32BitUrl  = '{{DownloadUrl}}'
 $validExitCodes = @(
     0 # success


### PR DESCRIPTION
In the next Version Visual Studio Code supports skipping the start of the application after installation (See https://github.com/Microsoft/vscode/issues/860). 

Should wait with merging until next Version (I assume 0.11) is out.