### PR TITLE
Update .NET dependency from 4.5.1 to 4.5.2

### DIFF
--- a/VisualStudioCode/VisualStudioCode.nuspec
+++ b/VisualStudioCode/VisualStudioCode.nuspec
@@ -35,7 +35,7 @@ For example: `-params '"/NoDesktopIcon /DontAddToPath"'`.
     </description>
     <tags>Microsoft VisualStudioCode vscode editor ide javascript typescript admin</tags>
     <dependencies>
-      <dependency id="DotNet4.5.1" />
+      <dependency id="DotNet4.5.2" />
     </dependencies>
     <releaseNotes>
         https://code.visualstudio.com/Updates


### PR DESCRIPTION
Update .NET Framework to a supported version.

.NET Blog:Support Ending for the .NET Framework 4, 4.5 and 4.5.1
https://blogs.msdn.microsoft.com/dotnet/2015/12/09/support-ending-for-the-net-framework-4-4-5-and-4-5-1/

Search product lifecycle:Microsoft .NET Framework 4.5
https://support.microsoft.com/en-us/lifecycle/search?alpha=Microsoft%20.NET%20Framework%204.5

Lifecycle support policy FAQ - Microsoft .NET Framework
https://support.microsoft.com/en-us/help/17455/lifecycle-support-policy-faq-net-framework